### PR TITLE
Changed patient identifier system url to fhir.nhs.uk/Id/nhs-number

### DIFF
--- a/pages/explore/get_an_appointment.md
+++ b/pages/explore/get_an_appointment.md
@@ -82,7 +82,7 @@ Where the request is made against the registry, the returned resource will ONLY 
 | status | `booked` \| `cancelled` \| `entered in error` | Indicates the state of the Appointment. |
 | start | instant | A full timestamp in <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601) of when the Appointment starts |
 | created | instant | When the resource was last updated <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601). |
-| participant | reference | A <a href='https://nhsconnect.github.io/fhir-policy/national-services.html#FHIR-NAT-01'>national service reference</a> to the Patient for whom this Appointment was booked, for example: `https://demographics.spineservices.nhs.uk|1234567890` where the Patient's NHS Number is 1234567890 |
+| participant | reference | A reference to the Patient for whom this Appointment was booked, for example: `https://fhir.nhs.uk/Id/nhs-number|1234567890` where the Patient's NHS Number is 1234567890 |
 
 ### From a provider system ###
 Where the request is made against a provider system, the resource will contain the details as defined in <a href='book_an_appointment.html'>Book an Appointment</a>, specifically:

--- a/pages/explore/get_an_appointment.md
+++ b/pages/explore/get_an_appointment.md
@@ -185,6 +185,9 @@ The DocumentReference resource **MUST** include the following data items:
             "meta": {
                 "profile": "https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-DocumentReference-1"
             },
+            "meta": {
+                "profile": "https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-DocumentReference-1"
+            },
             "identifier": {
                 "system": "https://tools.ietf.org/html/rfc4122",
                 "value": "A709A442-3CF4-476E-8377-376500E829C9"

--- a/pages/explore/get_an_appointment.md
+++ b/pages/explore/get_an_appointment.md
@@ -82,7 +82,7 @@ Where the request is made against the registry, the returned resource will ONLY 
 | status | `booked` \| `cancelled` \| `entered in error` | Indicates the state of the Appointment. |
 | start | instant | A full timestamp in <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601) of when the Appointment starts |
 | created | instant | When the resource was last updated <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601). |
-| participant | reference | A reference to the Patient for whom this Appointment was booked, for example: `https://fhir.nhs.uk/Id/nhs-number|1234567890` where the Patient's NHS Number is 1234567890 |
+| participant | reference | A reference to the Patient for whom this Appointment was booked, for example: `https://demographics.spineservices.nhs.uk/1234567890` where the Patient's NHS Number is 1234567890 |
 
 ### From a provider system ###
 Where the request is made against a provider system, the resource will contain the details as defined in <a href='book_an_appointment.html'>Book an Appointment</a>, specifically:

--- a/pages/explore/search_patient_appointments.md
+++ b/pages/explore/search_patient_appointments.md
@@ -91,7 +91,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
 | status | `booked` \| `cancelled` \| `entered in error` | Indicates the state of the Appointment. |
 | start | instant | A full timestamp in <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601) of when the Appointment starts |
 | created | instant | When the resource was last updated <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601). |
-| participant | reference | A <a href='https://nhsconnect.github.io/fhir-policy/national-services.html#FHIR-NAT-01'>national service reference</a> to the Patient for whom this Appointment was booked, for example: `https://fhir.nhs.uk/Id/nhs-number|1234567890` where the Patient's NHS Number is 1234567890 |
+| participant | reference | A <a href='https://nhsconnect.github.io/fhir-policy/national-services.html#FHIR-NAT-01'>national service reference</a> to the Patient for whom this Appointment was booked, for example: `https://demographics.spineservices.nhs.uk/1234567890` where the Patient's NHS Number is 1234567890 |
 
 ## Sample response ##
 

--- a/pages/explore/search_patient_appointments.md
+++ b/pages/explore/search_patient_appointments.md
@@ -38,7 +38,7 @@ The following query demonstrates a full request for information:
 <tr>
 <td>
 http://[FHIR base URL]/Appointment<br>
-?Appointment.participant.actor=https://demographics.spineservices.nhs.uk|1234554321
+?Appointment.participant.actor:Patient.identifier=https://fhir.nhs.uk/Id/nhs-number|1234567890
 </td>
 </tr>
 </table>
@@ -91,7 +91,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
 | status | `booked` \| `cancelled` \| `entered in error` | Indicates the state of the Appointment. |
 | start | instant | A full timestamp in <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601) of when the Appointment starts |
 | created | instant | When the resource was last updated <a href='http://hl7.org/fhir/STU3/datatypes.html#instant'>FHIR instant</a> format (ISO 8601). |
-| participant | reference | A <a href='https://nhsconnect.github.io/fhir-policy/national-services.html#FHIR-NAT-01'>national service reference</a> to the Patient for whom this Appointment was booked, for example: `https://demographics.spineservices.nhs.uk|1234567890` where the Patient's NHS Number is 1234567890 |
+| participant | reference | A <a href='https://nhsconnect.github.io/fhir-policy/national-services.html#FHIR-NAT-01'>national service reference</a> to the Patient for whom this Appointment was booked, for example: `https://fhir.nhs.uk/Id/nhs-number|1234567890` where the Patient's NHS Number is 1234567890 |
 
 ## Sample response ##
 
@@ -127,7 +127,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
                     <actor>
                         <identifier>
                             <use value="official"></use>
-                            <system value="https://demographics.spineservices.nhs.uk"></system>
+                            <system value="https://fhir.nhs.uk/Id/nhs-number"></system>
                             <value value="1234554321"></value>
                         </identifier>
                     </actor>
@@ -155,7 +155,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
                     <actor>
                         <identifier>
                             <use value="official"></use>
-                            <system value="https://demographics.spineservices.nhs.uk"></system>
+                            <system value="https://fhir.nhs.uk/Id/nhs-number"></system>
                             <value value="1234554321"></value>
                         </identifier>
                     </actor>
@@ -183,7 +183,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
                     <actor>
                         <identifier>
                             <use value="official"></use>
-                            <system value="https://demographics.spineservices.nhs.uk"></system>
+                            <system value="https://fhir.nhs.uk/Id/nhs-number"></system>
                             <value value="1234554321"></value>
                         </identifier>
                     </actor>
@@ -211,7 +211,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
                     <actor>
                         <identifier>
                             <use value="official"></use>
-                            <system value="https://demographics.spineservices.nhs.uk"></system>
+                            <system value="https://fhir.nhs.uk/Id/nhs-number"></system>
                             <value value="1234554321"></value>
                         </identifier>
                     </actor>
@@ -239,7 +239,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
                     <actor>
                         <identifier>
                             <use value="official"></use>
-                            <system value="https://demographics.spineservices.nhs.uk"></system>
+                            <system value="https://fhir.nhs.uk/Id/nhs-number"></system>
                             <value value="1234554321"></value>
                         </identifier>
                     </actor>
@@ -267,7 +267,7 @@ The response body WILL be a FHIR `Bundle` resource containing zero to many Appoi
                     <actor>
                         <identifier>
                             <use value="official"></use>
-                            <system value="https://demographics.spineservices.nhs.uk"></system>
+                            <system value="https://fhir.nhs.uk/Id/nhs-number"></system>
                             <value value="1234554321"></value>
                         </identifier>
                     </actor>

--- a/pages/fhir_resources/appointment.md
+++ b/pages/fhir_resources/appointment.md
@@ -205,6 +205,9 @@ The following data items in the <a href='get_an_appointment.html'>retrieved Appo
         {
             "resourceType": "DocumentReference",
             "id": "123",
+            "meta": {
+                "profile": "https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-DocumentReference-1"
+            },
             "identifier": {
                 "system": "https://tools.ietf.org/html/rfc4122",
                 "value": "A709A442-3CF4-476E-8377-376500E829C9"
@@ -371,6 +374,9 @@ The following data items in the <a href='get_an_appointment.html'>retrieved Appo
 
             "resourceType": "DocumentReference",
             "id": "123",
+            "meta": {
+                "profile": "https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-DocumentReference-1"
+            },
             "identifier": {
                 "system": "https://tools.ietf.org/html/rfc4122",
                 "value": "A709A442-3CF4-476E-8377-376500E829C9"

--- a/pages/fhir_resources/appointment.md
+++ b/pages/fhir_resources/appointment.md
@@ -65,7 +65,7 @@ The Appointment resource **MUST** include the following data items:
 | description | [1..1] | Text describing the need for the appointment, to be shown for example in an appointment list | Call to 111 about Headache |
 | slot | [1..1] | The Slot that this appointment is booked into | [ { "reference": "Slot/slot002" } ] |
 | supportingInformation | [1..1] | Reference to a contained resource (see below) which describes an associated document. | [ { "reference": "#123" } ] |
-| participant | [1..1] | A reference to a contained resource (see below) which describes the Patient for whom this Appointment is being booked | [ { "actor": { "reference": "#P1", "identifier": { "use": "official", "system": "https://demographics.spineservices.nhs.uk/", "value": "1234554321" }, "display": "Peter James Chalmers" }, "status": "accepted" } ] |
+| participant | [1..1] | A reference to a contained resource (see below) which describes the Patient for whom this Appointment is being booked | [ { "actor": { "reference": "#P1", "identifier": { "use": "official", "system": "https://fhir.nhs.uk/Id/nhs-number", "value": "1234554321" }, "display": "Peter James Chalmers" }, "status": "accepted" } ] |
 
 
 
@@ -142,7 +142,7 @@ When registering, the Appointment resource **MUST** include the following data i
 | identifier | [1..1] | The details of the appointment which is being registered | ... |
 | identifier.system | [1..1] | Defines that the value is a URL | Fixed value: `urn:ietf:rfc:3986` |
 | identifier.value | [1..1] | The URL of the appointment that is being registered | `https://ProviderBaseURL/Appointment/1234567890` |
-| participant | [1..1] | A reference to a contained resource (see below) which describes the <a href='patient.html'>Patient</a> for whom this Appointment is being booked | [ { "actor": { "reference": "#P1", "identifier": { "use": "official", "system": "https://demographics.spineservices.nhs.uk/", "value": "1234554321" }, "display": "Peter James Chalmers" }, "status": "accepted" } ] |
+| participant | [1..1] | A reference to a contained resource (see below) which describes the <a href='patient.html'>Patient</a> for whom this Appointment is being booked | [ { "actor": { "reference": "#P1", "identifier": { "use": "official", "system": "https://fhir.nhs.uk/Id/nhs-number", "value": "1234554321" }, "display": "Peter James Chalmers" }, "status": "accepted" } ] |
 
 
 

--- a/pages/fhir_resources/healthcare_service.md
+++ b/pages/fhir_resources/healthcare_service.md
@@ -22,5 +22,5 @@ The following FHIR elements are key to this implementation :
 | Element | Cardinality | Description | Example(s) |
 | --- | --- | --- | --- |
 | id | [1..1] | An id which has been retrieved from the DoS, this value is also the ASID of the Service, issued to the service when it is approved to go live by NHS Digital. This id will be the link to this resource from any Schedules. | 1231231234 |
-| providedBy | [0..1] | An optional reference to the <a href='organisation.html'>Organisation</a> which delivers this service | `{ "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/GD2" }` |
+| providedBy | [0..1] | An optional reference to the <a href='organisation.html'>Organisation</a> which delivers this service | `{ "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RR8" }` |
 | location | [0..1] | An optional reference to a <a href='location.html'>Location</a> resource, which describes where the service is. **NB: The 'user friendly' location of the service will already have been determined from the DoS when selecting this service, so this Location is far less important** | `{ "reference": "/Location/1237654" }` |


### PR DESCRIPTION
I've corrected the mistaken assumption that we would be using demographics.spineservices.nhs.uk style system to refer to Patients, reverting to the fhir.nhs.uk/Id/nhs-number one used elsewhere.