### PR TITLE
Changes required to remove ASID as the Service ID in HealthcareService FHIR resource and fix issue with appointment example profiles

### DIFF
--- a/pages/explore/search_free_slots.md
+++ b/pages/explore/search_free_slots.md
@@ -24,7 +24,7 @@ Provider systems **MUST** support the following search parameters that **MAY** b
 
 | Name | Type | Description | Paths |
 |---|---|---|---|
-| `service` | `token` | The ASID of the service for which Slots are being requested | `schedule.actor:healthcareservice` |
+| `service` | `token` | The appropriate service id of the service for which Slots are being requested | `schedule.actor:healthcareservice` |
 | `status` | `token` | The free/busy status of the slots | `status` |
 | `start` | `date` | Slot start date/time. | `start` |
 | `start` | `date` | Slot start date/time. | `start` |

--- a/pages/fhir_resources/appointment.md
+++ b/pages/fhir_resources/appointment.md
@@ -371,7 +371,10 @@ The following data items in the <a href='get_an_appointment.html'>retrieved Appo
     },
     "id": "efea8f22-0c33-4000-b4e7-a28569d65e91",
     "language": "en",
-    "text": "<div>Appointment</div>",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Appointment</div>"
+    },
     "contained": [
         {
 

--- a/pages/fhir_resources/appointment.md
+++ b/pages/fhir_resources/appointment.md
@@ -200,7 +200,10 @@ The following data items in the <a href='get_an_appointment.html'>retrieved Appo
         "profile": "https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Appointment-1"
     },
     "language": "en",
-    "text": "<div>Appointment</div>",
+    "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Appointment</div>"
+    },
     "contained": [
         {
             "resourceType": "DocumentReference",

--- a/pages/fhir_resources/healthcare_service.md
+++ b/pages/fhir_resources/healthcare_service.md
@@ -21,6 +21,6 @@ The following FHIR elements are key to this implementation :
 
 | Element | Cardinality | Description | Example(s) |
 | --- | --- | --- | --- |
-| id | [1..1] | An id which has been retrieved from an agreed Service Directory for the use case e.g the UEC Directory of Services (DoS) for UEC Appointment Booking, issued to the service when it is approved to go live by NHS Digital. This id will be the link to this resource from any Schedules. | 1231231234 |
+| id | [1..1] | An id which has been retrieved from an agreed Service Directory for the use case e.g the UEC Directory of Services (DoS) for UEC Appointment Booking, issued to the service when it is added to the agreed directory. This id will be the link to this resource from any Schedules. | 1231231234 |
 | providedBy | [0..1] | An optional reference to the <a href='organisation.html'>Organisation</a> which delivers this service | `{ "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RR8" }` |
 | location | [0..1] | An optional reference to a <a href='location.html'>Location</a> resource, which describes where the service is. **NB: The 'user friendly' location of the service will already have been determined from the DoS when selecting this service, so this Location is far less important** | `{ "reference": "/Location/1237654" }` |

--- a/pages/fhir_resources/healthcare_service.md
+++ b/pages/fhir_resources/healthcare_service.md
@@ -21,6 +21,6 @@ The following FHIR elements are key to this implementation :
 
 | Element | Cardinality | Description | Example(s) |
 | --- | --- | --- | --- |
-| id | [1..1] | An id which has been retrieved from the DoS, this value is also the ASID of the Service, issued to the service when it is approved to go live by NHS Digital. This id will be the link to this resource from any Schedules. | 1231231234 |
+| id | [1..1] | An id which has been retrieved from an agreed Service Directory for the use case e.g the UEC Directory of Services (DoS) for UEC Appointment Booking, issued to the service when it is approved to go live by NHS Digital. This id will be the link to this resource from any Schedules. | 1231231234 |
 | providedBy | [0..1] | An optional reference to the <a href='organisation.html'>Organisation</a> which delivers this service | `{ "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RR8" }` |
 | location | [0..1] | An optional reference to a <a href='location.html'>Location</a> resource, which describes where the service is. **NB: The 'user friendly' location of the service will already have been determined from the DoS when selecting this service, so this Location is far less important** | `{ "reference": "/Location/1237654" }` |

--- a/pages/fhir_resources/overview.md
+++ b/pages/fhir_resources/overview.md
@@ -12,9 +12,9 @@ summary: "This page provides an overview of the FHIR STU3 Resources that are req
 
 - The “disposition” from the patient interaction (NHS111 call etc) determines the urgency (giving the time constraints).
 - The DoS (Directory of Services) will have been <a href='process.html#getservices'>searched</a> and an appropriate service for the Patient selected.
-- Where the selected service offers appointment Booking, it will include an ASID value.
+- Where the selected service offers appointment Booking, it will include an value.
 - The ASID is used <a href='process.html#find-endpoint'>to locate the FHIR endpoint</a> to be queried.
-- A FHIR RESTful <a href='search_free_slots.html'>Search request is sent</a> to the FHIR endpoint for Slots that meet the time constraints, the ASID is passed as a constraint on the HealthcareService ID.
+- A FHIR RESTful <a href='search_free_slots.html'>Search request is sent</a> to the FHIR endpoint for Slots that meet the time constraints, the appropriate service id (e.g. from DoS) is passed as a constraint on the HealthcareService ID.
 - The specified HealthcareService may run zero to many Schedules.
 - Each Schedule may contain zero to many Slots.
 - The Slots are filtered using the Time constraints before being returned in a <a href='http://hl7.org/fhir/stu3/bundle.html#searchset'>searchset Bundle</a>.


### PR DESCRIPTION
Further investigation into the use of SDS and SSP for routing has highlighted that the ASID cannot be more granular than org level i.e. it cannot be used below ODS org code level, and so not usable for specific services below.
Therefore it has been decided that for this API to work another lower-level service id must be used from an agreed service directory.  In the case of UEC Appointment Booking in the pilot we will use the DOS Service ID.

Also the appointment resource examples were incorrect - the text field did not match the profile.

The updates in this pull request reflect the required changes.